### PR TITLE
Make Travis use environment specified in package file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ cache:
   directories:
     - "node_modules"
 
+before_install:
+  - nvm install $(jq -r '.engines.node' package.json)
+  - npm i -g npm@$(jq -r '.engines.npm' package.json)
+
 script: npm test -- --coverage
 
 after_success: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Lets enforce the environment that the application should run on.

Some big bugs were fixed from NPM v5.1 to now and the default version Travis use for Node v8.x is NPM v5.0.3. This PR will make sure Travis use the environment specified in `package.json`.